### PR TITLE
docs: Add UPnP/NAT-PMP support documentation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -533,14 +533,15 @@ Advantages:
 - Simple implementation
 - Works through proxies/firewalls
 - Easy debugging
-- No NAT traversal needed
+- No NAT traversal needed for public IP nodes
 - Most reliable for public IP nodes
+- UPnP/NAT-PMP support enables automatic port forwarding for NAT'd nodes
 
 Limitations:
 - No built-in swarming
 - Single-source per request
 - Higher overhead
-- Requires public IP or port forwarding
+- Requires public IP, manual port forwarding, or UPnP-capable router
 ```
 
 ##### 2. WebTorrent Protocol (WebRTC) (Default for NAT'd Nodes)
@@ -652,24 +653,30 @@ function selectDefaultSeedingProtocol(): Protocol {
   // Check if node has public IP
   if (hasPublicIP()) {
     return Protocol.HTTP; // DEFAULT for public IP nodes
-  } else {
-    // Behind NAT
-    // [DECISION NEEDED]: WebTorrent or BitTorrent as default?
-    return Protocol.WebTorrent; // Current default for NAT'd nodes
-    // OR
-    // return Protocol.BitTorrent;  // Alternative (needs discussion)
   }
+  
+  // Behind NAT - try UPnP first
+  if (tryUPnPPortForward()) {
+    return Protocol.HTTP; // Use HTTP if UPnP succeeds
+  }
+  
+  // UPnP failed or unavailable
+  // [DECISION NEEDED]: WebTorrent or BitTorrent as default?
+  return Protocol.WebTorrent; // Current default for NAT'd nodes
+  // OR
+  // return Protocol.BitTorrent;  // Alternative (needs discussion)
 }
 ```
 
 **Default Protocol Matrix**:
 
 ```
-Network Capability      → Default Seeding Protocol
-─────────────────────────────────────────────────
-Public IP               → HTTP
-Behind NAT              → WebTorrent (or BitTorrent? TBD)
-Browser Only            → WebTorrent (only option)
+Network Capability              → Default Seeding Protocol
+───────────────────────────────────────────────────────────
+Public IP                       → HTTP
+Behind NAT + UPnP Available     → HTTP (auto port forward)
+Behind NAT + UPnP Failed        → WebTorrent (or BitTorrent? TBD)
+Browser Only                    → WebTorrent (only option)
 ```
 
 #### Protocol Selection Strategy (Downloader Side)

--- a/docs/nat-traversal.md
+++ b/docs/nat-traversal.md
@@ -158,6 +158,39 @@ The network uses a multi-layered approach to ensure connectivity:
 ### 1. Direct Connection (fastest)
 For publicly reachable peers with no NAT or firewall restrictions.
 
+#### Automatic Port Forwarding (UPnP/NAT-PMP)
+Modern routers support automatic port forwarding protocols that enable NAT'd peers to become publicly reachable without manual configuration:
+
+- **UPnP (Universal Plug and Play)**: Industry-standard protocol for automatic port mapping
+  - Discovers IGD (Internet Gateway Device) on the local network via SSDP multicast
+  - Requests external port mappings through SOAP/XML API
+  - Router exposes internal service on its public IP address
+  - Widely supported on consumer routers (check router settings: "UPnP" or "UPnP IGD")
+
+- **NAT-PMP (NAT Port Mapping Protocol)**: Lightweight alternative protocol
+  - Simpler protocol designed by Apple for home routers
+  - Commonly found on Apple AirPort and BSD-based routers
+  - Uses UDP packets for port mapping requests
+  - Faster negotiation than UPnP
+
+**Benefits**:
+- Transforms NAT'd nodes into publicly reachable peers automatically
+- Eliminates need for manual port forwarding configuration
+- Improves network performance by enabling direct P2P connections
+- Reduces relay bandwidth usage
+
+**Fallback Strategy**:
+- If UPnP/NAT-PMP fails (unsupported router, disabled, or restrictive firewall)
+- Automatically proceeds to Hole Punching (DCUtR)
+- Circuit Relay used as final fallback
+
+**Connection Priority**:
+```
+1. Try UPnP/NAT-PMP → Direct connection if successful
+2. If failed → Hole Punching (DCUtR)
+3. If failed → Circuit Relay
+```
+
 ### 2. Hole Punching (DCUtR)
 For symmetric NAT traversal using Direct Connection Upgrade through Relay protocol.
 


### PR DESCRIPTION
## Summary
Documents UPnP/NAT-PMP automatic port forwarding support for enabling HTTP protocol on NAT'd nodes.

## What is UPnP/NAT-PMP?

**UPnP (Universal Plug and Play)**
- Industry-standard protocol for automatic port mapping
- Routers expose IGD (Internet Gateway Device) service
- Applications can request external port forwarding via SSDP discovery and SOAP/XML API
- Widely supported on consumer routers (needs to be enabled in router settings)

**NAT-PMP (NAT Port Mapping Protocol)**
- Lightweight alternative protocol designed by Apple
- Simpler than UPnP, uses UDP packets for port mapping requests
- Common on Apple AirPort and BSD-based routers
- Faster negotiation compared to UPnP

## Benefits
- Enables direct connections for NAT'd nodes without manual port forwarding
- Allows NAT'd nodes to serve files via HTTP protocol
- Simpler protocol stack compared to WebRTC/BitTorrent for NAT traversal
- Reduces dependency on STUN/TURN servers or relay nodes

## Changes
- Added UPnP/NAT-PMP to NAT traversal documentation
- Updated HTTP protocol documentation to include UPnP support
- Modified protocol selection logic to attempt UPnP before falling back to WebTorrent/BitTorrent

## Documentation Updates
- **docs/nat-traversal.md**: Added UPnP/NAT-PMP section under Direct Connection
- **docs/architecture.md**: Updated HTTP protocol advantages and default protocol selection

## Protocol Selection Logic

The system now follows this protocol selection order:

1. If the node has a public IP → Use HTTP (default for public nodes)
2. If behind NAT → Try UPnP/NAT-PMP automatic port forwarding
   - If UPnP succeeds → Use HTTP (with forwarded port)
   - If UPnP fails → Fall back to WebTorrent or BitTorrent (decision pending)
3. If browser-only environment → Use WebTorrent (only option)

**Network Capability to Protocol Matrix:**
- Public IP → HTTP
- Behind NAT + UPnP Available → HTTP (auto port forward)
- Behind NAT + UPnP Failed → WebTorrent (or BitTorrent? TBD)
- Browser Only → WebTorrent (only option)

## Future Work
This PR documents the architecture. Implementation will follow in subsequent PRs:
- Rust UPnP/NAT-PMP client library integration (e.g., `igd-next` crate)
- Automatic port mapping attempt on HTTP server startup
- HTTP server external address publishing to DHT
- Fallback to WebTorrent/BitTorrent on UPnP failure

Related to automatic port forwarding for NAT'd nodes.